### PR TITLE
Changed Azure command to AZ

### DIFF
--- a/Instructions/Labs/Mod06/20535A_LAB_AK_06.md
+++ b/Instructions/Labs/Mod06/20535A_LAB_AK_06.md
@@ -143,7 +143,7 @@
 1. Type in the following command and press **Enter** to create a new **Network Interface Card**:
 
     ```
-    azure network nic create --resource-group MOD06VMDK --name ComputeNIC --location eastus --subnet-name ComputeSubnet --subnet-vnet-name ComputeNetwork
+    az network nic create --resource-group MOD06VMDK --name ComputeNIC --location eastus --subnet ComputeSubnet --vnet-name ComputeNetwork
     ```
 
 1. Type in the following command and press **Enter** to view the details of your newly created *Network Interface Card*:


### PR DESCRIPTION
Changed azure network to az network command

# Module: 6
## Lab: Exercise 1

Fixes # .
Changed old azure command into az

Changes proposed in this pull request:

old:
azure network nic create --resource-group MOD06VMDK --name ComputeNIC --location eastus --subnet-name ComputeSubnet --subnet-vnet-name ComputeNetwork

new:
az network nic create --resource-group MOD06VMDK --name ComputeNIC --location eastus --subnet ComputeSubnet --vnet-name ComputeNetwork

-
-
-
