### PR TITLE
Task 3.2 incorrect syntax

### DIFF
--- a/Instructions/Labs/Mod08/20535A_LAB_AK_08.md
+++ b/Instructions/Labs/Mod08/20535A_LAB_AK_08.md
@@ -89,7 +89,7 @@
 1. In the **Cloud Shell** command prompt at the bottom of the portal, type in the following command and press **Enter** to list all resource groups in the subscription:
 
     ```
-    az vm extension set --publisher Microsoft.Azure.Extensions --version 2.0 --name CustomScript --vm-name MyUbuntuVM --resource-group MOD08LSVM --settings '{"commandToExecute":"apt-get -y update && apt-get -y install apache2"}'
+    az vm extension set --publisher Microsoft.Azure.Extensions --version 2.0 --name CustomScript --vm-name MyUbuntuVM --resource-group MOD08LSVM --settings '{"commandToExecute":"apt-get -y update && apt-get install -y apache2"}'
     ```
 
 1. Wait for the **extension** to finish installing before moving on with this lab.


### PR DESCRIPTION
It has the -y in the wrong place. 
original (fails) = apt-get -y install apache2
my edit (works) = apt-get install -y apache2

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-
