### PR TITLE
Reference it's the Node.js app

### DIFF
--- a/Instructions/Labs/Mod05/20535A_LAB_AK_05.md
+++ b/Instructions/Labs/Mod05/20535A_LAB_AK_05.md
@@ -179,7 +179,7 @@
 
     a. In the **Resource group** section, locate the list and select the **MOD05APPS** option.
 
-    a. In the **Web App Name** field, enter the unique name of the **Web App** you created earlier in this lab.
+    a. In the **Web App Name** field, enter the unique name of the Node.js **Web App** you created earlier in this lab.
 
     a. In the **Repository Url** field, enter the value **https://github.com/Azure-Samples/nodejs-docs-hello-world**.
 


### PR DESCRIPTION
# Module: 05
## Lab: 05

Fixes #58 .

Changes proposed in this pull request:
- Reference it's the Node.js app. This way is more clear that you should use the name of the previous created app.
