### PR TITLE
standard_A1_v2 no longer exists

### DIFF
--- a/Allfiles/Mod03/Labfiles/Starter/vmss.json
+++ b/Allfiles/Mod03/Labfiles/Starter/vmss.json
@@ -33,7 +33,7 @@
             "overprovisionInstances": "[parameters('overprovision')]"
         },
         "vm": {
-            "size": "Standard_A1_v2",
+            "size": "Standard_A1",
             "authentication": {
                 "username": "Student",
                 "password": "StudentPa55w.rd"


### PR DESCRIPTION
changed to standard_A1

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-
