### PR TITLE
VM size standard_A1_v1 no longer exists

### DIFF
--- a/Allfiles/Mod09/Labfiles/Starter/vaultvm.json
+++ b/Allfiles/Mod09/Labfiles/Starter/vaultvm.json
@@ -87,7 +87,7 @@
             ],
             "properties": {
                 "hardwareProfile": {
-                    "vmSize": "Standard_A1_v2"
+                    "vmSize": "Standard_A1"
                 },
                 "osProfile": {
                     "computerName": "[variables('vmName')]",


### PR DESCRIPTION
changed to standard_A1

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-
