### PR TITLE
VM size standard_A1_v2 no longer exists

### DIFF
--- a/Allfiles/Mod06/Labfiles/Starter/manageddisk.json
+++ b/Allfiles/Mod06/Labfiles/Starter/manageddisk.json
@@ -17,7 +17,7 @@
             "location": "[resourceGroup().location]",
             "properties": {
                 "hardwareProfile": {
-                    "vmSize": "Standard_A1_v2"
+                    "vmSize": "Standard_A1"
                 },
                 "osProfile": {
                     "computerName": "[variables('vmName')]",


### PR DESCRIPTION
changed to Standard_A1

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-
